### PR TITLE
chore: add build test workflow

### DIFF
--- a/.github/workflows/build-verification.yaml
+++ b/.github/workflows/build-verification.yaml
@@ -1,0 +1,59 @@
+name: Build Verification
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.css"
+      - "**/*.vue"
+      - "**/*.json"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "**/package.json"
+  push:
+    branches: ["main"]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.css"
+      - "**/*.vue"
+      - "**/*.json"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "**/package.json"
+
+jobs:
+  build:
+    name: Build Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda #v4.1.0
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run build
+        run: pnpm build
+
+      - name: Verify build artifacts
+        run: |
+          if [ ! -f "dist/plugin_package.zip" ]; then
+            echo "Build failed: plugin_package.zip not found"
+            exit 1
+          fi


### PR DESCRIPTION
# ci build workflow init

**Key Changes:**

- [ ] adds simple github workflow for testing a build

**Added:**

- [ ] adds simple github workflow for testing a build
---

## Generated Summary:

- Introduced a new GitHub Actions workflow for build verification.
- The workflow triggers on `pull_request` and `push` events to the `main` branch.
- Monitors the following file types for changes: 
  - TypeScript (`*.ts`, `*.tsx`)
  - CSS (`*.css`)
  - Vue files (`*.vue`)
  - JSON files (`*.json`)
  - Project-specific files (`package.json`, `pnpm-lock.yaml`)
- The workflow includes steps for:
  - Checking out the code.
  - Setting up Node.js with version 20 and caching `pnpm` dependencies.
  - Setting up `pnpm` without installing dependencies initially.
  - Installing project dependencies using `pnpm`.
  - Running the build process.
  - Verifying that the build artifact `plugin_package.zip` exists.
- Ensures that the build fails clearly if the expected artifact is not found.
- This PR adds automated checks to enhance code quality and prevent broken builds from being merged into the `main` branch.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
