### PR TITLE
fix: build workflow

### DIFF
--- a/.github/workflows/build-verification.yaml
+++ b/.github/workflows/build-verification.yaml
@@ -33,17 +33,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
-        with:
-          node-version: 20
-          cache: "pnpm"
-
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda #v4.1.0
         with:
           version: 9
           run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
+        with:
+          node-version: 20
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
# fixup build-verification workflow,

**Key Changes:**

- [ ] fixup build-verification workflow, ie [here](https://github.com/GangGreenTemperTatum/MethodCheck/actions/runs/14816792120/job/41598285396?pr=7) from #7 #9 

**Changed:**

In the setup-node step, it was specifying cache: "pnpm"
This tells the action to look for pnpm and use it for dependency caching
But pnpm isn't installed yet - that happens in the next step with `pnpm/action-setup`

- [ ] First, pnpm is installed with `pnpm/action-setup`. Then, Node.js is set up with caching using the `now-available` pnpm
---

## Generated Summary:

- Reordered the setup steps in the workflow for improved organization.
- Moved the "Setup Node.js" step to follow the "Setup pnpm" step.
- The "Setup Node.js" configuration remains unchanged.
- No functional changes; just enhances readability of the workflow.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
