### PR TITLE
feat: include interval id polling

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -7,6 +7,8 @@ const processedRequests = new Set<string>();
 let lastRequestId: string | null = null;
 // Store the cursor from the last query for pagination
 let lastCursor: string | null = null;
+// Store the interval ID for polling
+let pollingIntervalId: ReturnType<typeof setInterval> | null = null;
 
 // Simple URL parser function to extract host and path
 function parseUrl(sdk: SDK, url: string): { host: string, path: string } {
@@ -305,13 +307,45 @@ async function checkRequest(sdk: SDK, requestId: string): Promise<string> {
 
 // Function to start the periodic polling
 async function startPolling(sdk: SDK): Promise<void> {
+  // Only start polling if it's not already running
+  if (pollingIntervalId !== null) {
+    sdk.console.log(`[MethodCheck] Polling already active, not starting again`);
+    return;
+  }
+
   // Poll immediately, then every 5 seconds
   await pollForRequests(sdk);
 
   // Continue polling at regular intervals
-  setInterval(async () => {
+  pollingIntervalId = setInterval(async () => {
     await pollForRequests(sdk);
   }, 5000);
+
+  sdk.console.log(`[MethodCheck] Polling started with interval ID: ${pollingIntervalId}`);
+}
+
+// Function to stop the periodic polling
+function stopPolling(sdk: SDK): boolean {
+  if (pollingIntervalId === null) {
+    sdk.console.log(`[MethodCheck] No active polling to stop`);
+    return false;
+  }
+
+  clearInterval(pollingIntervalId);
+  pollingIntervalId = null;
+  sdk.console.log(`[MethodCheck] Polling stopped`);
+  return true;
+}
+
+// Function to toggle polling state
+function togglePolling(sdk: SDK): boolean {
+  if (pollingIntervalId === null) {
+    startPolling(sdk);
+    return true; // Polling is now active
+  } else {
+    stopPolling(sdk);
+    return false; // Polling is now inactive
+  }
 }
 
 // Function to create a test finding
@@ -355,12 +389,16 @@ If you see this, it means the findings API is working correctly!`,
 // Export the API type
 export type API = DefineAPI<{
   checkRequest: typeof checkRequest;
+  togglePolling: typeof togglePolling;
+  isPollingActive: () => boolean;
 }>;
 
 // Initialize the plugin
 export function init(sdk: SDK<API>) {
   // Register the API
   sdk.api.register("checkRequest", checkRequest);
+  sdk.api.register("togglePolling", () => togglePolling(sdk));
+  sdk.api.register("isPollingActive", () => pollingIntervalId !== null);
 
   // Listen for proxy responses
   try {

--- a/packages/frontend/src/hooks/useCaidoSDK.ts
+++ b/packages/frontend/src/hooks/useCaidoSDK.ts
@@ -1,0 +1,6 @@
+import { inject } from 'vue';
+import type { CaidoSDK } from '../index';
+
+export function useCaidoSDK(): CaidoSDK | null {
+  return inject<CaidoSDK>('sdk') || null;
+}

--- a/packages/frontend/src/views/App.vue
+++ b/packages/frontend/src/views/App.vue
@@ -29,9 +29,47 @@
         History and selecting <strong>Check Available Methods</strong>.
       </p>
     </div>
+
+    <div class="mb-4">
+      <p class="mb-2">
+        This plugin checks for alternative HTTP methods that are allowed on
+        endpoints.
+      </p>
+      <button
+        class="px-4 py-2 rounded"
+        :class="
+          pollingActive
+            ? 'bg-red-500 hover:bg-red-600'
+            : 'bg-green-500 hover:bg-green-600'
+        "
+        @click="togglePolling"
+      >
+        {{ pollingActive ? "Disable Polling" : "Enable Polling" }}
+      </button>
+      <span class="ml-2 text-sm" v-if="pollingActive">Polling is active</span>
+      <span class="ml-2 text-sm" v-else>Polling is inactive</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// No additional script needed for this simple informational view
+import { ref, onMounted } from "vue";
+import { useCaidoSDK } from "../hooks/useCaidoSDK";
+
+const sdk = useCaidoSDK();
+const pollingActive = ref(false);
+
+// Check initial polling state
+onMounted(async () => {
+  if (sdk) {
+    pollingActive.value = await sdk.api.isPollingActive();
+  }
+});
+
+// Toggle polling function
+const togglePolling = async () => {
+  if (sdk) {
+    pollingActive.value = await sdk.api.togglePolling();
+  }
+};
 </script>


### PR DESCRIPTION
# feat: interval id polling

**Key Changes:**

- [ ] aims to close #21 , still testing but so far LGTM

- Store the polling interval ID so we can reference and clear it later
- Add functions to start, stop, and toggle polling
- Expose new API methods to control polling from the frontend
- Create a simple UI for users to toggle polling
- Show the current polling state to the user

**Added:**

- [ ] polling ID and state to expose new API methods to control polling from the frontend