### PR TITLE
chore: rm erroneous ref commands from sdk

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -283,23 +283,16 @@ async function checkRequest(sdk: SDK, requestId: string): Promise<string> {
     const result = await processRequest(sdk, requestId);
 
     if (result) {
-      if (sdk.toast) {
-        sdk.toast.success(`Found methods: ${result}`);
-      }
+      sdk.console.log(`[MethodCheck] Manual check successful, found methods: ${result}`);
       return result;
     } else {
-      if (sdk.toast) {
-        sdk.toast.info('No additional methods found');
-      }
+      sdk.console.log(`[MethodCheck] Manual check completed, no additional methods found`);
       return "";
     }
   } catch (error) {
     sdk.console.error(`[MethodCheck] Error in manual check: ${error}`);
     if (error instanceof Error) {
       sdk.console.error(`[MethodCheck] Error stack: ${error.stack}`);
-    }
-    if (sdk.toast) {
-      sdk.toast.error('Failed to check methods');
     }
     return "";
   }

--- a/packages/frontend/src/index.ts
+++ b/packages/frontend/src/index.ts
@@ -1,11 +1,16 @@
 import { SDK } from "caido:plugin";
-import type { API } from "../../backend/src/index";
+import type { API, BackendEvents } from "../../backend/src/index";
 import App from './views/App.vue';
 
-export type CaidoSDK = SDK<API>;
+export type CaidoSDK = SDK<API, BackendEvents>;
 
 export function init(sdk: CaidoSDK) {
   console.log("[MethodCheck] Frontend initializing...");
+
+  // Listen for method check events from backend
+  sdk.backend.onEvent("method-check-result", (data) => {
+    console.log(`[MethodCheck] Found methods for ${data.url}: ${data.availableMethods.join(', ')}`);
+  });
 
   // Register our plugin's view
   if (sdk.view) {


### PR DESCRIPTION
# cleanup erroneous Caido SDK refs and housekeeping cleanup

**Key Changes:**

- [ ] aims to address errors in #16 and reduce code complexity

**Added:**

- [ ] Add proper event type definitions using DefineEvents

**Changed:**

- [ ] Update the backend to send events to the frontend when methods are found
- [ ] Update the frontend to listen for these events

**Removed:**

- [ ] refs to `.sdk.commands`
- [ ] refs to `sdk.toast`
- [ ] removed additional verbose `sdk.console` logging

---

<!-- Delete any sections that are not applicable -->
<!-- Add screenshots or code examples if relevant -->
