### PR TITLE
fix: Renovate/add renovate janitor python v3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
   "pre-commit": {
     "enabled": true
   },
-  "enabledManagers": ["npm", "github-actions", "pip_requirements"],
+  "enabledManagers": ["npm", "github-actions"],
   "timezone": "America/New_York",
   "schedule": ["before 4am"],
   "labels": ["dependency"],
@@ -63,13 +63,6 @@
       "automergeType": "pr"
     }
   ],
-  "includePaths": [
-    "tests/**",
-    "tests/flask-options-app/**"
-  ],
-  "pip_requirements": {
-    "fileMatch": ["(^|/)([\\w-])*requirements.*\\.txt$"]
-  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
   "pre-commit": {
     "enabled": true
   },
-  "enabledManagers": ["npm", "github-actions"],
+  "enabledManagers": ["npm", "github-actions", "pip_requirements"],
   "timezone": "America/New_York",
   "schedule": ["before 4am"],
   "labels": ["dependency"],


### PR DESCRIPTION
# fix renovate just add `enabledManagers` `pip_requirements`

**Key Changes:**

- [ ] think i broke renovate in #32 #33 #1
---

## Generated Summary:

- Removed the `includePaths` configuration which specified directories for Renovate to include during dependency updates.
- Removed the `pip_requirements` section that defined file matching patterns for pip requirements files.
- The removal of these configurations may simplify the Renovate setup but could impact dependency management for files in the previous include paths.
- Vulnerability alerts remain enabled with specified labels for security tagging.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
